### PR TITLE
RAW_SYLLABLES input format support

### DIFF
--- a/dev/prosody/src/treeton/prosody/musimatix/VerseProcessor.java
+++ b/dev/prosody/src/treeton/prosody/musimatix/VerseProcessor.java
@@ -642,6 +642,45 @@ public class VerseProcessor {
         }
     }
 
+    void parseRawSyllables(ArrayList<String> rawSyllableStrings, ArrayList<String> plainOutput, ArrayList<StressDescription> stressDescriptions) throws Exception {
+        for (String syllableString : rawSyllableStrings) {
+            int bracketIndex = syllableString.indexOf('(');
+            if(bracketIndex >= 0) {
+                syllableString = syllableString.substring(0, bracketIndex);
+            }
+            String[] syllables = syllableString.split(";");
+
+            ArrayList<SyllableInfo> syllInfos = new ArrayList<>();
+            StringBuilder buf = new StringBuilder();
+            int prevEnd = -1;
+            for (String syllable : syllables) {
+                if(syllable.isEmpty()) {
+                    continue;
+                }
+
+                String[] syllDescr = syllable.split(",");
+
+                int shift = Integer.valueOf(syllDescr[0]);
+                int length = Integer.valueOf(syllDescr[1]);
+                boolean stressed = syllDescr[2].equals("S");
+
+                if(prevEnd >= 0 && prevEnd != shift) {
+                    buf.append(' ');
+                }
+
+                prevEnd = shift + length;
+
+                syllInfos.add(new SyllableInfo(buf.length(),2,
+                        stressed ? SyllableInfo.StressStatus.STRESSED : SyllableInfo.StressStatus.UNSTRESSED));
+
+                buf.append("ла");
+            }
+
+            plainOutput.add(buf.toString());
+            stressDescriptions.add(new StressDescription(syllInfos));
+        }
+    }
+
     public Vector<Double> countAverage(ArrayList<VerseDescription> verseDescriptions, int firstLineIndex) {
         Vector<Double> averageVector = new Vector<>();
         averageVector.setSize(metricVectorDimension);

--- a/runtime/verseProcessing.properties
+++ b/runtime/verseProcessing.properties
@@ -38,9 +38,17 @@ noMorph=false
 secondPass=true
 # Calculate metric fragments during analysis. If this option is true metric characteristics of metric fragments will be taken into account on the second pass.
 calculateFragments=true
-# Do treat input verses as formatted (trying to locate "{bla}" and "{bla'}" fragments which mean forced stressed and unstressed zones correspondingly)
-parseFormattedLyrics=false
-# If this parameter is true only average metric vectors will be written in output files 
+# Currently three input formats are supported:
+#     STANDARD - text with optional header,
+#     FORMATTED - some text fragments may be explicitly marked as stressed or unstressed.
+#       Expressions like "{bla}" or "{bla'}" specify stressed and unstressed zones correspondingly
+#     RAW_SYLLABLES - no input text is provided, only syllable structure. In this mode tool expects to
+#       see syllable sequences described using exactly the same format as one that is used for the output when
+#       compactOutput flag is set to true
+inputFormat=RAW_SYLLABLES
+# If set to true tool will not try to detect header with meta information in the input file - all lines will be analysed as lyrics
+noHeader=False
+# If this parameter is true only average metric vectors will be written in output files
 compactOutput=true
 # Number of nonempty verses that will be used to count average metric vector (use -1 to take all verses into account)
 numberOfVersesForAverageVector=-1


### PR DESCRIPTION
Добавил возможность подавать на вход verseProcessingTool просто последователности слогов, без текста. Внутри они преврщаются в "ла ла ла" и все работает по-старому.